### PR TITLE
No -fno-plt

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,11 +1,11 @@
 CHOST:
 - x86_64-pc-windows-msvc19.14.26423
 FINAL_CFLAGS:
-- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -fno-plt -O2
-  -ffunction-sections -pipe
+- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections
+  -pipe
 FINAL_CXXFLAGS:
 - -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -march=k8 -mtune=haswell
-  -ftree-vectorize -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections -pipe
 MSVC_HEADERS_VERSION:
 - 14.14.26423
 WINSDK_VERSION:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -1,11 +1,11 @@
 CHOST:
 - x86_64-pc-windows-msvc19.14.26423
 FINAL_CFLAGS:
-- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -fno-plt -O2
-  -ffunction-sections -pipe
+- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections
+  -pipe
 FINAL_CXXFLAGS:
 - -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -march=k8 -mtune=haswell
-  -ftree-vectorize -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections -pipe
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 MSVC_HEADERS_VERSION:

--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -1,9 +1,9 @@
 FINAL_CFLAGS:
-- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -fno-plt -O2
-  -ffunction-sections -pipe
+- -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections
+  -pipe
 FINAL_CXXFLAGS:
 - -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -march=k8 -mtune=haswell
-  -ftree-vectorize -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections -pipe
 MSVC_HEADERS_VERSION:
 - 14.14.26423
 VER:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,10 +6,10 @@ VER:
 # FINAL_* entries are taken from the linux64 entries in ctng-compiler-activation-feedstock
 # Removed -fPIC
 FINAL_CFLAGS:
-  - -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  - -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections -pipe
 
 FINAL_CXXFLAGS:
-  - -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
+  - -fvisibility-inlines-hidden -std=c++14 -fmessage-length=0 -march=k8 -mtune=haswell -ftree-vectorize -fstack-protector-strong -O2 -ffunction-sections -pipe
 
 WINSDK_VERSION:
   - 10.0.17763.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: winsdk


### PR DESCRIPTION
Don't add `-fno-plt` to the `*FLAGS` as position independent code options are not actually used to the nature of the DLL loading on Windows. In addition, in some situations this also causes `clang` to crash instead of ignoring the option.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
