### PR TITLE
make clang-cl activation compatible with flang

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,5 +1,5 @@
-# This file was added automatically by admin-migrations. Do not modify.
-# It ensures that Github Actions can run once rerendered for the first time.
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
 name: Build conda package

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RATTLER_CACHE_DIR="${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache"
 
 cat >~/.condarc <<CONDARC
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -28,13 +28,6 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
-    # The default cache location might not be writable using docker on macOS.
-    if ns.config.startswith("linux") and platform.system() == "Darwin":
-        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
-            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
-            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
-        )
-
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/activate-clang-cl_win-64.bat
+++ b/recipe/activate-clang-cl_win-64.bat
@@ -8,6 +8,12 @@ set "AR=llvm-ar.exe"
 set "RANLIB=llvm-ranlib.exe"
 
 set "CPPFLAGS_USED=-DNDEBUG -D_CRT_SECURE_NO_WARNINGS -fms-runtime-lib=dll -fuse-ld=lld"
+
 set "LDFLAGS=/DEFAULTLIB:%CONDA_PREFIX:\=/%/lib/clang/@MAJOR_VER@/lib/windows/clang_rt.builtins-x86_64.lib"
+REM `-Xlinker` was only exposed in v20. It is needed for compatibility with the `flang` CLI
+if "@MAJOR_VER@" GEQ "20" (
+    set "LDFLAGS=-Xlinker %LDFLAGS%"
+)
+
 set "CFLAGS=@CFLAGS@ %CPPFLAGS_USED%"
 set "CXXFLAGS=@CXXFLAGS@ /std:c++17 %CPPFLAGS_USED%"

--- a/recipe/activate-clang-cl_win-64.ps1
+++ b/recipe/activate-clang-cl_win-64.ps1
@@ -6,6 +6,12 @@ $Env:AR="llvm-ar.exe"
 $Env:RANLIB="llvm-ranlib.exe"
 
 $Env:CPPFLAGS_USED="-DNDEBUG -D_CRT_SECURE_NO_WARNINGS -fms-runtime-lib=dll -fuse-ld=lld"
-$Env:LDFLAGS="/DEFAULTLIB:" + $Env:CONDA_PREFIX.Replace('\', '/') +"/lib/clang/@MAJOR_VER@/lib/windows/clang_rt.builtins-x86_64.lib"
+
+$Env:LDFLAGS="/DEFAULTLIB:" + $Env:CONDA_PREFIX.Replace('\', '/') + "/lib/clang/@MAJOR_VER@/lib/windows/clang_rt.builtins-x86_64.lib"
+# `-Xlinker` was only exposed in v20. It is needed for compatibility with the `flang` CLI
+if (@MAJOR_VER@ -ge 20) {
+    $Env:LDFLAGS = "-Xlinker " + $Env:LDFLAGS
+}
+
 $Env:CFLAGS="@CFLAGS@ " + $Env:CPPFLAGS_USED
 $Env:CXXFLAGS="@CXXFLAGS@ /std:c++17 " + $Env:CPPFLAGS_USED

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,11 +3,11 @@
 {% set CL_VERSION = "19.29" %}
 {% set VCVER = "" %}
 {% endif %}
-{% set clang_major = CLANG_VERSION.split(".")[0] %}
+{% set clang_major = CLANG_VERSION.split(".")[0] | int %}
 {% set cl_minor = CL_VERSION.split(".")[1] %}
 {% set vc_major = VCVER.split(".")[0] %}
 
-{% set build_number = 23 %}
+{% set build_number = 24 %}
 
 # separate builds number for headers & winsdk; reset when version increases (resp. all relevant versions)
 {% set headers_build_number = 5 %}
@@ -15,7 +15,7 @@
 
 package:
   name: clang-win-activation
-  version: {{ CLANG_VERSION }}
+  version: "{{ CLANG_VERSION }}"
 
 source:
   # not the main source, but a very useful download utility to determine
@@ -193,6 +193,7 @@ outputs:
       requires:
         - cmake
         - ninja
+        - flang_win-64      # [clang_major >= 20]
       files:
         - cmake_test_c/
         - cmake_test_cxx/
@@ -200,7 +201,10 @@ outputs:
         - test.cpp
         - run_test_clang.bat
         - run_test_clangxx.bat
+        - sanitycheckf.f    # [clang_major >= 20]
       commands:
+        - flang-new sanitycheckf.f -o sanitycheckf.exe %FFLAGS% %LDFLAGS%"  # [clang_major >= 20]
+        - sanitycheckf.exe  # [clang_major >= 20]
         - run_test_clang.bat
         - run_test_clangxx.bat
 

--- a/recipe/sanitycheckf.f
+++ b/recipe/sanitycheckf.f
@@ -1,0 +1,4 @@
+! from https://github.com/mesonbuild/meson/blob/1.9.0/mesonbuild/compilers/fortran.py#L66
+      PROGRAM MAIN
+      PRINT *, "Fortran compilation is working."
+      END


### PR DESCRIPTION
closes gh-65
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
